### PR TITLE
Modified the limits of the noise source grid and increased the maximum lag of cross-correlations

### DIFF
--- a/noisi/scripts/correlation.py
+++ b/noisi/scripts/correlation.py
@@ -245,14 +245,21 @@ def get_ns(all_conf, insta=False):
     # n = next_fast_len(2 * nt - 1)
 
     # Number of time steps for synthetic correlation
-    n_lag = int(all_conf.source_config['max_lag'] * Fs)
-    if nt - 2 * n_lag <= 0:
+    n_lag_float = all_conf.source_config['max_lag'] * Fs
+    n_lag = int(n_lag_float)
+
+    if not n_lag_float.is_integer():
+        warn('Resetting maximum lag to %g seconds:\
+ %g seconds is not an integer multiple of the sampling rate.' %
+ (n_lag/Fs, n_lag_float/Fs))
+
+    if n_lag > nt:
         n_lag_old = n_lag
-        n_lag = nt // 2
+        n_lag = nt
         warn('Resetting maximum lag to %g seconds:\
  Synthetics are too short for %g seconds.' % (n_lag / Fs, n_lag_old / Fs))
 
-    n_corr = 2 * n_lag + 1
+    n_corr = 2 * n_lag - 1
 
     return nt, n, n_corr, Fs
 

--- a/noisi/util/geo.py
+++ b/noisi/util/geo.py
@@ -197,7 +197,7 @@ def points_on_ell(dx, xmin=-180., xmax=180., ymin=-89.999, ymax=89.999):
         d_lon = dx / len_deg_lon(lat)
         # the starting point of each longitudinal circle is randomized
         perturb = np.random.rand(1)[0] * d_lon - 0.5 * d_lon
-        lon = min(max(xmin + perturb, -180.), 180.)
+        lon = min(max(xmin + perturb, xmin), xmax)
 
         while lon <= xmax:
             gridx.append(lon)


### PR DESCRIPTION
Hi Laura,

I made the following changes on two commits:

- Commit 1: Fixed a problem during the source-grid generation, where some grid points might be outside the xmin and xmax limits defined by the user.

- Commit 2: According to the zero-padding length defined in line 60 of my_classes/wavefield.py, the tool performs linear cross-correlation. Therefore, I modified the code so the user can store a maximum lag up to the Green's function's duration. Also, I added a warning when the user-defined maximum lag is not an integer multiple of the sampling rate, leading to a slightly different value.

Best wishes,
Eduardo.